### PR TITLE
Add full Linux compatibility for CLI and GUI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,125 @@
+name: build
+
+on:
+  push:
+    branches: [main, master]
+    tags: ["v*"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          # protoc for protobuf codegen; libGL/EGL/xcb for PySide6 import under xvfb
+          sudo apt-get install -y --no-install-recommends \
+            protobuf-compiler xvfb \
+            libgl1 libegl1 libxkbcommon0 \
+            libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+            libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xinerama0
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[development]
+
+      - name: Generate protobuf modules
+        run: bash gen_pb2.sh
+
+      - name: Run tests
+        run: xvfb-run -a pytest
+
+  build-linux:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            protobuf-compiler libfuse2 \
+            libgl1 libegl1 libxkbcommon0 \
+            libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+            libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xinerama0
+
+      - name: Install package + PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pyinstaller
+
+      - name: Generate protobuf modules
+        run: bash gen_pb2.sh
+
+      - name: Build AppImage
+        run: bash scripts/build_appimage.sh
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: DwarfAlpacaGUI-linux-x86_64
+          path: dist/*.AppImage
+
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.AppImage
+
+  build-windows:
+    needs: test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install package + PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pyinstaller
+
+      - name: Generate protobuf modules
+        shell: bash
+        run: bash gen_pb2.sh
+
+      - name: Build executable
+        run: pyinstaller --noconfirm packaging/dwarf_alpaca_gui.spec
+
+      - name: Upload exe artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: DwarfAlpacaGUI-windows-x86_64
+          path: dist/DwarfAlpacaGUI.exe
+
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/DwarfAlpacaGUI.exe

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ dwarf_python_api/
 build/
 dist/
 DwarfAlpacaGUI.spec
+*.AppImage
+AppDir/
 logs/
 dwarfii_api/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 1. Fork the repo & create a feature branch.
 2. Test changes.
-3. Submit a PR with description.
+3. Ensure CI comes back green.
+4. Submit a PR with description.
 
 All contributions are automatically licensed under GPLv3.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ An ASCOM Alpaca device hub for the DWARF 3 smart telescope. The project speaks t
 ### 1. Prerequisites
 
 - Python 3.10+
-- Windows PowerShell (repo commands assume Windows; adjust paths for macOS/Linux)
+- A shell: commands below use Windows PowerShell; for macOS/Linux use the POSIX
+  equivalents (`source .venv/bin/activate`, `export VAR=value`). Linux users
+  should also see [`setup_linux.md`](setup_linux.md).
 - System packages required by `aiortc` / `av` (FFmpeg, libopus, etc.)
 - Optional: Bluetooth adapter compatible with [Bleak](https://github.com/hbldh/bleak)
+  (on Linux this needs BlueZ and a running `bluetooth` service)
 
 ### 2. Create a virtual environment
 
@@ -71,7 +74,7 @@ pip install -e .[development]
 
 | Scenario | How to run |
 | --- | --- |
-| **Simulation** | `setx DWARF_ALPACA_FORCE_SIMULATION true` (or use PowerShell `$env:DWARF_ALPACA_FORCE_SIMULATION = "true"` in-session) then `dwarf-alpaca serve`. The routers respond with synthetic data, ideal for UI development and tests. |
+| **Simulation** | Set `DWARF_ALPACA_FORCE_SIMULATION=true` then `dwarf-alpaca serve`. PowerShell: `$env:DWARF_ALPACA_FORCE_SIMULATION = "true"`; POSIX shell: `export DWARF_ALPACA_FORCE_SIMULATION=true`. The routers respond with synthetic data, ideal for UI development and tests. |
 | **Hardware (existing Wi-Fi)** | Ensure the DWARF is connected to your Wi-Fi and that its STA IP is recorded in `var/connectivity.json` (or supply `--ssid`/`--password`). Run `dwarf-alpaca start --skip-provision --wait-timeout 180`. |
 | **Hardware (provisioning required)** | Use the BLE guide to onboard Wi-Fi credentials: `dwarf-alpaca guide --adapter <optional-device> --ble-password <password>`. Credentials and STA IP are saved for subsequent runs. |
 
@@ -86,35 +89,39 @@ dwarf-alpaca start --ssid "MySSID" --password "MyPassword"
 - Provisions the telescope, waits for STA connectivity, acquires the master lock, and starts the HTTP + discovery services.
 - STA IP detection automatically updates `Settings.dwarf_ap_ip` before the server boots.
 
-> Looking for the packaged Windows GUI? Follow the step-by-step guide in [`setup.md`](setup.md) to launch the compiled Control Center and configure clients such as NINA.
+> Looking for the packaged GUI? Follow [`setup.md`](setup.md) for the Windows Control Center, or [`setup_linux.md`](setup_linux.md) for the Linux AppImage and CLI, including how to configure clients such as NINA.
 
 ---
 
-## Building the GUI Executable
+## Building the GUI
 
-Package the PySide6 control center into a standalone Windows executable with [PyInstaller](https://pyinstaller.org):
+The PySide6 Control Center freezes into a standalone artifact with
+[PyInstaller](https://pyinstaller.org) using the shared, cross-platform spec at
+`packaging/dwarf_alpaca_gui.spec`. Install PyInstaller once per environment
+(`pip install pyinstaller`) and generate the protobuf modules first
+(`bash gen_pb2.sh`).
 
-1. Activate the virtual environment (if not already active):
+### Windows (`.exe`)
 
-  ```powershell
-  .\venv\Scripts\Activate.ps1
-  ```
+```powershell
+pyinstaller --noconfirm packaging\dwarf_alpaca_gui.spec
+```
 
-2. Install PyInstaller (one time per environment):
+The packaged binary is created at `dist\DwarfAlpacaGUI.exe`.
 
-  ```powershell
-  pip install pyinstaller
-  ```
+### Linux (AppImage)
 
-3. Build the executable:
+```bash
+bash scripts/build_appimage.sh
+```
 
-  ```powershell
-  pyinstaller --noconfirm --onefile --windowed --name DwarfAlpacaGUI --icon images/dwarfalplogo.ico --add-data "images;images" --add-data "var;var" --paths src run_gui.py
-  ```
+This runs PyInstaller with the same spec, assembles an AppDir (binary,
+`.desktop`, icon, `AppRun`), and wraps it with `appimagetool` into
+`dist/DwarfAlpacaGUI-x86_64.AppImage`. See [`setup_linux.md`](setup_linux.md)
+for the host libraries required to build and run it.
 
-  The packaged binary will be created at `dist\DwarfAlpacaGUI.exe`. Update the `--add-data` entries if you need more resources bundled.
-
-4. Launch the app directly from the `dist` directory to verify everything runs as expected.
+Both artifacts are also produced automatically by CI
+(`.github/workflows/build.yml`) and attached to tagged releases.
 
 ---
 

--- a/packaging/dwarf-alpaca-gui.desktop
+++ b/packaging/dwarf-alpaca-gui.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=DWARF Alpaca Control Center
+GenericName=Telescope Control
+Comment=ASCOM Alpaca server for the DWARF 3 smart telescope
+Exec=DwarfAlpacaGUI
+Icon=dwarfalplogo
+Terminal=false
+Categories=Science;Utility;
+Keywords=astronomy;telescope;alpaca;ascom;dwarf;

--- a/packaging/dwarf_alpaca_gui.spec
+++ b/packaging/dwarf_alpaca_gui.spec
@@ -1,0 +1,65 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for the DWARF Alpaca Control Center GUI.
+
+Cross-platform: PyInstaller resolves the data-file path separator itself, so the
+same spec produces a Windows ``.exe`` and a Linux binary (the latter is wrapped
+into an AppImage by ``scripts/build_appimage.sh``).
+
+Build with::
+
+    pyinstaller packaging/dwarf_alpaca_gui.spec
+"""
+
+import sys
+from pathlib import Path
+
+# Paths in a spec are resolved relative to the spec file's directory, so anchor
+# everything at the repository root (the parent of packaging/) for robustness
+# regardless of the working directory PyInstaller is invoked from. SPECPATH is
+# injected by PyInstaller and points at this spec file's directory.
+REPO_ROOT = Path(SPECPATH).resolve().parent
+IMAGES = REPO_ROOT / "images"
+
+# Windows gets the .ico (embedded into the executable); other platforms use the
+# PNG (the AppImage desktop icon is handled separately by the build script).
+if sys.platform.startswith("win"):
+    icon_file = str(IMAGES / "dwarfalplogo.ico")
+else:
+    icon_file = str(IMAGES / "dwarfalplogo.png")
+
+a = Analysis(
+    [str(REPO_ROOT / "run_gui.py")],
+    pathex=[str(REPO_ROOT / "src")],
+    binaries=[],
+    datas=[(str(IMAGES), "images")],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="DwarfAlpacaGUI",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=icon_file,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,13 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
+classifiers = [
+  "Operating System :: OS Independent",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: Microsoft :: Windows",
+  "Programming Language :: Python :: 3",
+  "Topic :: Scientific/Engineering :: Astronomy",
+]
 dependencies = [
   "fastapi>=0.118.2",
   "uvicorn[standard]>=0.37.0",

--- a/run_gui.py
+++ b/run_gui.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
 import os
-import sys
-from pathlib import Path
 
 from dwarf_alpaca.gui.app import main
+from dwarf_alpaca.paths import portable_base_dir
 
 
 def _set_working_directory() -> None:
-    if getattr(sys, "frozen", False):
-        base_dir = Path(sys.executable).resolve().parent
-    else:
-        base_dir = Path(__file__).resolve().parent
-    os.chdir(base_dir)
+    os.chdir(portable_base_dir())
 
 
 if __name__ == "__main__":

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Build the DWARF Alpaca Control Center as a portable Linux AppImage.
+#
+# Steps:
+#   1. Freeze the PySide6 GUI with PyInstaller using the shared spec.
+#   2. Assemble an AppDir (binary + .desktop + icon + AppRun).
+#   3. Wrap it into dist/DwarfAlpacaGUI-x86_64.AppImage with appimagetool.
+#
+# Prerequisites: python3 + pip, pyinstaller, protoc (for gen_pb2.sh), and the
+# system libraries PySide6 needs at runtime (libGL, libEGL, xcb-*). FUSE is
+# required to *run* the resulting AppImage; appimagetool itself is downloaded
+# here and run via its embedded runtime.
+set -euo pipefail
+
+SCRIPT_PATH="$(realpath -- "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+ARCH="${ARCH:-x86_64}"
+APP_NAME="DwarfAlpacaGUI"
+DIST_DIR="$REPO_DIR/dist"
+APPDIR="$DIST_DIR/AppDir"
+APPIMAGETOOL_VERSION="${APPIMAGETOOL_VERSION:-continuous}"
+APPIMAGETOOL="$DIST_DIR/appimagetool-$ARCH.AppImage"
+
+cd "$REPO_DIR"
+
+echo "==> Ensuring generated protobuf modules exist"
+if ! ls "$REPO_DIR"/src/dwarf_alpaca/proto/*_pb2.py >/dev/null 2>&1; then
+    bash "$REPO_DIR/gen_pb2.sh"
+fi
+
+echo "==> Freezing GUI with PyInstaller"
+pyinstaller --noconfirm packaging/dwarf_alpaca_gui.spec
+
+echo "==> Assembling AppDir at $APPDIR"
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin"
+mkdir -p "$APPDIR/usr/share/applications"
+mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+install -m 0755 "$DIST_DIR/$APP_NAME" "$APPDIR/usr/bin/$APP_NAME"
+
+# Desktop entry (required at the AppDir root and conventionally also under usr/share)
+cp "$REPO_DIR/packaging/dwarf-alpaca-gui.desktop" "$APPDIR/dwarf-alpaca-gui.desktop"
+cp "$REPO_DIR/packaging/dwarf-alpaca-gui.desktop" "$APPDIR/usr/share/applications/"
+
+# Icon (top-level icon name must match the desktop entry's Icon= key)
+cp "$REPO_DIR/images/dwarfalplogo.png" "$APPDIR/dwarfalplogo.png"
+cp "$REPO_DIR/images/dwarfalplogo.png" \
+    "$APPDIR/usr/share/icons/hicolor/256x256/apps/dwarfalplogo.png"
+
+# AppRun launcher
+cat > "$APPDIR/AppRun" <<'EOF'
+#!/bin/bash
+HERE="$(dirname "$(readlink -f "${0}")")"
+exec "$HERE/usr/bin/DwarfAlpacaGUI" "$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+echo "==> Fetching appimagetool ($APPIMAGETOOL_VERSION)"
+if [ ! -x "$APPIMAGETOOL" ]; then
+    curl -fsSL -o "$APPIMAGETOOL" \
+        "https://github.com/AppImage/appimagetool/releases/download/$APPIMAGETOOL_VERSION/appimagetool-$ARCH.AppImage"
+    chmod +x "$APPIMAGETOOL"
+fi
+
+echo "==> Building AppImage"
+OUTPUT="$DIST_DIR/$APP_NAME-$ARCH.AppImage"
+# --appimage-extract-and-run avoids needing FUSE just to *build* the image.
+ARCH="$ARCH" "$APPIMAGETOOL" --appimage-extract-and-run "$APPDIR" "$OUTPUT"
+
+echo "==> Done: $OUTPUT"

--- a/setup_linux.md
+++ b/setup_linux.md
@@ -1,0 +1,168 @@
+# DWARF Alpaca on Linux
+
+This guide covers running the DWARF 3 Alpaca server on Linux — both the
+graphical **Control Center** (shipped as a portable **AppImage**) and the
+`dwarf-alpaca` command-line interface. The Windows-focused walkthrough lives in
+[`setup.md`](setup.md); this is its Linux counterpart.
+
+---
+
+## 1. Host prerequisites
+
+The AppImage bundles Python and the PySide6/Qt runtime, but a few system pieces
+must be present on the host:
+
+| Need | Why | Debian/Ubuntu | Fedora |
+| --- | --- | --- | --- |
+| FUSE | Required to run any AppImage | `sudo apt install libfuse2` | `sudo dnf install fuse-libs` |
+| Qt platform libs | PySide6 GUI rendering | `sudo apt install libgl1 libegl1 libxkbcommon0 libxcb-cursor0` | `sudo dnf install mesa-libGL libxkbcommon libxcb` |
+| BlueZ | BLE provisioning (`Provisioning` tab / `guide`) | `sudo apt install bluez` | `sudo dnf install bluez` |
+
+For BLE, make sure the Bluetooth service is running and you have a powered
+adapter:
+
+```bash
+sudo systemctl enable --now bluetooth
+bluetoothctl list      # confirm a controller is present (e.g. hci0)
+```
+
+> If you only need simulation mode or hardware that is already on your Wi-Fi,
+> BlueZ is optional.
+
+---
+
+## 2. Run the GUI (AppImage)
+
+1. Download `DwarfAlpacaGUI-x86_64.AppImage` from the project releases.
+2. Make it executable and launch it:
+
+   ```bash
+   chmod +x DwarfAlpacaGUI-x86_64.AppImage
+   ./DwarfAlpacaGUI-x86_64.AppImage
+   ```
+
+The Control Center opens on the **Server** tab. Usage of the Server,
+Provisioning, and Settings tabs is identical to the Windows guide
+([`setup.md`](setup.md) sections 2–5).
+
+> **Where state is stored:** runtime state (`var/connectivity.json`, logs) is
+> written **next to the `.AppImage` file**, mirroring the portable behaviour of
+> the Windows `.exe`. Keep the AppImage in a writable directory (e.g. your home
+> folder), not on a read-only mount. To store state elsewhere, set
+> `DWARF_ALPACA_STATE_DIRECTORY=/absolute/path`.
+
+### Bluetooth adapter on Linux
+
+When a field or flag asks for a BLE **adapter**, Linux uses HCI device names
+(`hci0`, `hci1`, …) — not the Windows-style device descriptions. Leave it blank
+to use the default adapter, or pass `--adapter hci0` on the CLI.
+
+---
+
+## 3. Run the CLI
+
+Install into an isolated environment (recommended) or a virtualenv:
+
+```bash
+# Isolated, with the console entry points on your PATH
+pipx install dwarf-alpaca
+
+# …or a regular virtualenv from a checkout
+python -m venv .venv && . .venv/bin/activate
+pip install -e .
+bash gen_pb2.sh          # generate protobuf modules (needs protobuf-compiler)
+```
+
+Common commands (full table in the [README](README.md)):
+
+```bash
+# Simulation: serve synthetic devices, no hardware needed
+DWARF_ALPACA_FORCE_SIMULATION=true dwarf-alpaca serve
+
+# Hardware, all-in-one provision + serve
+dwarf-alpaca start --ssid "MySSID" --password "MyPassword"
+
+# Interactive BLE onboarding using a specific adapter
+dwarf-alpaca guide --adapter hci0 --ble-password DWARF_12345678
+```
+
+Settings come from `DWARF_ALPACA_*` environment variables, a `.env` file, or a
+YAML profile via `--config`. Unlike the Windows guide's PowerShell syntax, use
+POSIX shell exports:
+
+```bash
+export DWARF_ALPACA_HTTP_PORT=11800
+export DWARF_ALPACA_FORCE_SIMULATION=true
+dwarf-alpaca serve
+```
+
+---
+
+## 4. Firewall
+
+Alpaca clients reach the server over TCP (HTTP, default `11111`) and UDP
+discovery (default `32227`). With `ufw`:
+
+```bash
+sudo ufw allow 11111/tcp
+sudo ufw allow 32227/udp
+```
+
+---
+
+## 5. Run as a background service (optional)
+
+To keep the server running headless, install a per-user systemd unit at
+`~/.config/systemd/user/dwarf-alpaca.service`:
+
+```ini
+[Unit]
+Description=DWARF Alpaca server
+After=network-online.target bluetooth.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/dwarf-alpaca
+ExecStart=%h/.local/bin/dwarf-alpaca serve
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+Then enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now dwarf-alpaca
+journalctl --user -u dwarf-alpaca -f   # follow logs
+```
+
+Adjust `WorkingDirectory` so that the portable `var/` directory lands where you
+want state stored (or set `DWARF_ALPACA_STATE_DIRECTORY` in the unit's
+`Environment=`).
+
+---
+
+## 6. Building the AppImage yourself
+
+From a checkout with `protobuf-compiler`, `pyinstaller`, and the Qt/FUSE
+libraries above installed:
+
+```bash
+pip install -e . pyinstaller
+bash scripts/build_appimage.sh
+# -> dist/DwarfAlpacaGUI-x86_64.AppImage
+```
+
+The script freezes the GUI with `packaging/dwarf_alpaca_gui.spec`, assembles an
+AppDir (binary, `.desktop`, icon, `AppRun`), and wraps it with `appimagetool`.
+
+---
+
+## 7. Configure NINA and other clients
+
+Client setup is platform-independent — follow [`setup.md`](setup.md) section 6.
+Point clients at the host/port the server reports; if running NINA on Windows
+against a Linux host, make sure the Linux firewall (section 4) allows the Alpaca
+ports.

--- a/src/dwarf_alpaca/cli.py
+++ b/src/dwarf_alpaca/cli.py
@@ -28,7 +28,7 @@ def _configure_start_logging(settings: Settings) -> None:
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         log_path = log_dir / f"dwarf-alpaca-start-{timestamp}.log"
     except Exception as exc:  # pragma: no cover - defensive
-        logger.warning("cli.start.logfile_init_failed", error=str(exc))
+        logger.warning("cli.start.logfile_init_failed error=%s", exc)
         return
 
     root_logger = logging.getLogger()

--- a/src/dwarf_alpaca/dwarf/ble_provisioner.py
+++ b/src/dwarf_alpaca/dwarf/ble_provisioner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import sys
 from dataclasses import dataclass
 from typing import Any, Optional, TYPE_CHECKING, cast
 
@@ -39,6 +40,50 @@ else:  # pragma: no cover
 logger = structlog.get_logger(__name__)
 
 
+# BlueZ returns this error from Device.Connect() for GATT-only LE peripherals
+# (like the DWARF): the LE link comes up and services resolve, but no classic
+# profile attaches, so BlueZ reports "No more profiles to connect to". bleak
+# treats it as fatal, while phones simply ignore it and use GATT directly.
+_TOLERATED_BLUEZ_CONNECT_ERRORS = frozenset({"org.bluez.Error.BREDR.ProfileUnavailable"})
+
+_bluez_workaround_installed = False
+
+
+def _install_bluez_profile_workaround() -> None:
+    """Make bleak's BlueZ backend ignore the spurious ProfileUnavailable error.
+
+    Patches the ``assert_reply`` reference used by bleak's connect path so that
+    the single ``BREDR.ProfileUnavailable`` error is swallowed (GATT is already
+    usable at that point) while every other D-Bus failure still raises. No-op on
+    non-Linux platforms and idempotent.
+    """
+
+    global _bluez_workaround_installed
+    if _bluez_workaround_installed or not sys.platform.startswith("linux"):
+        return
+    try:  # pragma: no cover - depends on bleak's BlueZ backend being importable
+        from bleak.backends.bluezdbus import client as bluez_client
+    except Exception:  # pragma: no cover - non-BlueZ build
+        return
+
+    original_assert_reply = getattr(bluez_client, "assert_reply", None)
+    if original_assert_reply is None:  # pragma: no cover - unexpected bleak layout
+        return
+
+    def _tolerant_assert_reply(reply: Any) -> None:
+        if getattr(reply, "error_name", None) in _TOLERATED_BLUEZ_CONNECT_ERRORS:
+            logger.warning(
+                "ble.provision.bluez_profile_unavailable_ignored",
+                error_name=getattr(reply, "error_name", None),
+            )
+            return
+        original_assert_reply(reply)
+
+    bluez_client.assert_reply = _tolerant_assert_reply
+    _bluez_workaround_installed = True
+    logger.info("ble.provision.bluez_profile_workaround_installed")
+
+
 def _is_ble_device(candidate: Any) -> bool:
     return (
         candidate is not None
@@ -62,6 +107,7 @@ class DwarfBleProvisioner:
 
     def __init__(self, *, response_timeout: float = 15.0) -> None:
         self.response_timeout = response_timeout
+        _install_bluez_profile_workaround()
 
     @staticmethod
     async def discover_devices(

--- a/src/dwarf_alpaca/dwarf/ble_provisioner.py
+++ b/src/dwarf_alpaca/dwarf/ble_provisioner.py
@@ -84,6 +84,23 @@ def _install_bluez_profile_workaround() -> None:
     logger.info("ble.provision.bluez_profile_workaround_installed")
 
 
+# Standard 16-bit Bluetooth SIG services we never want to send DWARF commands to
+# (GAP, GATT, device info, PnP). Anything else is treated as a vendor/custom
+# service and preferred when auto-selecting the command characteristic.
+_STANDARD_SERVICE_PREFIXES = (
+    "00001800",  # Generic Access
+    "00001801",  # Generic Attribute
+    "00001804",  # Tx Power
+    "0000180a",  # Device Information
+    "00001200",  # PnP Information
+)
+
+
+def _looks_custom_service(uuid: str) -> bool:
+    normalized = uuid.lower()
+    return not any(normalized.startswith(prefix) for prefix in _STANDARD_SERVICE_PREFIXES)
+
+
 def _is_ble_device(candidate: Any) -> bool:
     return (
         candidate is not None
@@ -107,7 +124,57 @@ class DwarfBleProvisioner:
 
     def __init__(self, *, response_timeout: float = 15.0) -> None:
         self.response_timeout = response_timeout
+        # Resolved per-connection in _resolve_characteristic(); defaults to the
+        # DWARF 3 characteristic so behaviour is unchanged if discovery is skipped.
+        self._active_char_uuid = DWARF_CHARACTERISTIC_UUID
         _install_bluez_profile_workaround()
+
+    def _resolve_characteristic(self, client: BleakClientType) -> str:
+        """Pick the GATT characteristic to talk to, across DWARF models.
+
+        The DWARF 3 exposes the command characteristic at
+        ``00009999-…`` under service ``daf2``/``daf3``; the DWARF mini uses a
+        different layout (service ``daf5``). Rather than hard-code per model,
+        log the full GATT table and select a characteristic that supports both
+        write and notify, preferring the known DWARF 3 UUID, then a custom
+        (vendor) service, then any candidate. Falls back to the DWARF 3 UUID.
+        """
+
+        services = getattr(client, "services", None) or []
+        default_present = False
+        candidates: list[tuple[int, str]] = []
+        for service in services:
+            svc_uuid = str(service.uuid).lower()
+            for ch in service.characteristics:
+                ch_uuid = str(ch.uuid).lower()
+                props = {p.lower() for p in ch.properties}
+                logger.info(
+                    "ble.provision.gatt_char",
+                    service=svc_uuid,
+                    characteristic=ch_uuid,
+                    properties=sorted(props),
+                )
+                if ch_uuid == DWARF_CHARACTERISTIC_UUID:
+                    default_present = True
+                can_write = bool(props & {"write", "write-without-response"})
+                can_notify = bool(props & {"notify", "indicate"})
+                if can_write and can_notify:
+                    priority = 0 if _looks_custom_service(svc_uuid) else 1
+                    candidates.append((priority, ch_uuid))
+
+        if default_present:
+            chosen = DWARF_CHARACTERISTIC_UUID
+            reason = "known-dwarf3-uuid"
+        elif candidates:
+            candidates.sort(key=lambda item: item[0])
+            chosen = candidates[0][1]
+            reason = "auto-discovered"
+        else:
+            chosen = DWARF_CHARACTERISTIC_UUID
+            reason = "fallback-no-candidate"
+
+        logger.info("ble.provision.characteristic_selected", characteristic=chosen, reason=reason)
+        return chosen
 
     @staticmethod
     async def discover_devices(
@@ -158,7 +225,8 @@ class DwarfBleProvisioner:
                 loop.call_soon_threadsafe(_put)
 
             try:
-                await client.start_notify(DWARF_CHARACTERISTIC_UUID, _notification_handler)
+                self._active_char_uuid = self._resolve_characteristic(client)
+                await client.start_notify(self._active_char_uuid, _notification_handler)
                 config = await self._write_and_wait_for_config(
                     client,
                     response_queue,
@@ -186,7 +254,7 @@ class DwarfBleProvisioner:
                 return ProvisioningResult(False, f"Provisioning failed: {exc}")
             finally:
                 with contextlib.suppress(Exception):
-                    await client.stop_notify(DWARF_CHARACTERISTIC_UUID)
+                    await client.stop_notify(self._active_char_uuid)
 
     async def _discover_device(self, adapter: str | None) -> Optional[BLEDevice]:
         logger.info("ble.provision.scan", adapter=adapter)
@@ -253,10 +321,11 @@ class DwarfBleProvisioner:
 
                 loop.call_soon_threadsafe(_put)
 
-            await client.start_notify(DWARF_CHARACTERISTIC_UUID, _notification_handler)
+            self._active_char_uuid = self._resolve_characteristic(client)
+            await client.start_notify(self._active_char_uuid, _notification_handler)
             try:
                 await client.write_gatt_char(
-                    DWARF_CHARACTERISTIC_UUID,
+                    self._active_char_uuid,
                     build_req_getconfig(ble_password),
                     response=True,
                 )
@@ -270,7 +339,7 @@ class DwarfBleProvisioner:
                     )
 
                 await client.write_gatt_char(
-                    DWARF_CHARACTERISTIC_UUID,
+                    self._active_char_uuid,
                     build_req_getwifilist(),
                     response=True,
                 )
@@ -289,7 +358,7 @@ class DwarfBleProvisioner:
                         return list(wifi_response.ssid)
             finally:
                 with contextlib.suppress(Exception):
-                    await client.stop_notify(DWARF_CHARACTERISTIC_UUID)
+                    await client.stop_notify(self._active_char_uuid)
 
     async def _write_and_wait_for_config(
         self,
@@ -300,7 +369,7 @@ class DwarfBleProvisioner:
         deadline: float,
     ) -> Any:
         await client.write_gatt_char(
-            DWARF_CHARACTERISTIC_UUID,
+            self._active_char_uuid,
             build_req_getconfig(ble_psd),
             response=True,
         )
@@ -351,7 +420,7 @@ class DwarfBleProvisioner:
             "ble.provision.send_sta", ssid=ssid, auto_start=auto_start
         )
         await client.write_gatt_char(
-            DWARF_CHARACTERISTIC_UUID,
+            self._active_char_uuid,
             build_req_sta(auto_start, ble_psd, ssid, password),
             response=True,
         )
@@ -377,7 +446,7 @@ class DwarfBleProvisioner:
                     break
                 logger.info("ble.provision.query_followup")
                 await client.write_gatt_char(
-                    DWARF_CHARACTERISTIC_UUID,
+                    self._active_char_uuid,
                     build_req_getconfig(ble_psd),
                     response=True,
                 )

--- a/src/dwarf_alpaca/gui/app.py
+++ b/src/dwarf_alpaca/gui/app.py
@@ -700,7 +700,7 @@ class MainWindow(QMainWindow):
         worker.start()
 
     def _handle_worker_error(self, exc: Exception, context: str) -> None:
-        logger.error("gui.worker.failure", context=context, error=str(exc))
+        logger.error("gui.worker.failure context=%s, error=%s", context,exc)
         QMessageBox.critical(self, "Error", f"{context}: {exc}")
 
     # endregion

--- a/src/dwarf_alpaca/gui/app.py
+++ b/src/dwarf_alpaca/gui/app.py
@@ -44,6 +44,7 @@ except Exception:  # pragma: no cover - Python < 3.9 or missing tzdata
 from ..config.settings import Settings, load_settings, normalize_dwarf_device_model
 from ..dwarf.ble_provisioner import DwarfBleProvisioner, ProvisioningError
 from ..dwarf.state import ConnectivityState, StateStore
+from ..paths import bundled_resource_dir, portable_base_dir
 from ..provisioning.workflow import create_state_store, provision_sta
 from ..cli import _configure_start_logging, _preflight_session
 from .logging import QtLogHandler
@@ -54,7 +55,10 @@ from .workers import AsyncWorker
 logger = logging.getLogger(__name__)
 
 
-APP_ICON_PATH = Path(__file__).resolve().parents[3] / "images" / "dwarfalplogo.ico"
+# Prefer PNG (loads reliably via Qt on every platform); fall back to the
+# Windows .ico. Resolved against the bundle-aware resource directory so it works
+# both in a source checkout and inside a PyInstaller bundle.
+APP_ICON_NAMES = ("dwarfalplogo.png", "dwarfalplogo.ico")
 
 
 def _load_timezone_choices() -> list[str]:
@@ -453,20 +457,19 @@ class ServerControlWidget(QGroupBox):
 
 
 def _load_app_icon() -> QIcon:
-    if APP_ICON_PATH.exists():
-        return QIcon(str(APP_ICON_PATH))
-    logger.warning("gui.icon.missing path=%s", APP_ICON_PATH)
+    images_dir = bundled_resource_dir() / "images"
+    for name in APP_ICON_NAMES:
+        candidate = images_dir / name
+        if candidate.exists():
+            return QIcon(str(candidate))
+    logger.warning("gui.icon.missing dir=%s names=%s", images_dir, APP_ICON_NAMES)
     return QIcon()
 
 
 def _resolve_state_directory(path: Path) -> Path:
     if path.is_absolute():
         return path
-    if getattr(sys, "frozen", False):
-        base = Path(sys.executable).resolve().parent
-    else:
-        base = Path.cwd()
-    return (base / path).resolve()
+    return (portable_base_dir() / path).resolve()
 
 
 class MainWindow(QMainWindow):

--- a/src/dwarf_alpaca/gui/app.py
+++ b/src/dwarf_alpaca/gui/app.py
@@ -700,7 +700,7 @@ class MainWindow(QMainWindow):
         worker.start()
 
     def _handle_worker_error(self, exc: Exception, context: str) -> None:
-        logger.error("gui.worker.failure context=%s, error=%s", context,exc)
+        logger.error("gui.worker.failure context=%s, error=%s", context, exc)
         QMessageBox.critical(self, "Error", f"{context}: {exc}")
 
     # endregion

--- a/src/dwarf_alpaca/paths.py
+++ b/src/dwarf_alpaca/paths.py
@@ -1,0 +1,45 @@
+"""Cross-platform path helpers shared by the CLI and GUI."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def portable_base_dir() -> Path:
+    """Return the directory that portable runtime state lives next to.
+
+    The server keeps its state (``var/``: ``connectivity.json``, logs, etc.)
+    alongside the distributed artifact so a release is self-contained. The
+    resolution differs by how the app is being run:
+
+    * **AppImage** – the binary executes from a read-only FUSE mount, so
+      ``sys.executable`` points *inside* that mount. AppImage exposes the real
+      on-disk path of the ``.AppImage`` file via the ``APPIMAGE`` environment
+      variable; state therefore lives next to that file.
+    * **PyInstaller .exe / onefile** – next to the bundled executable.
+    * **Source checkout** – the current working directory.
+    """
+
+    appimage = os.environ.get("APPIMAGE")
+    if appimage:
+        return Path(appimage).resolve().parent
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return Path.cwd()
+
+
+def bundled_resource_dir() -> Path:
+    """Return the directory containing bundled data resources (``images/``).
+
+    When frozen by PyInstaller, data added via ``--add-data`` is extracted to a
+    temporary directory exposed as ``sys._MEIPASS``. In a source checkout the
+    resources live at the repository root.
+    """
+
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        return Path(meipass)
+    # src/dwarf_alpaca/paths.py -> repository root
+    return Path(__file__).resolve().parents[2]

--- a/tests/test_gui_settings.py
+++ b/tests/test_gui_settings.py
@@ -1,10 +1,12 @@
 import pytest
+import os
 
 from PySide6.QtWidgets import QApplication, QMessageBox
 
 from dwarf_alpaca.gui.app import MainWindow
 from dwarf_alpaca.dwarf.state import ConnectivityState
 
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 @pytest.fixture(scope="module")
 def qapp():


### PR DESCRIPTION
The project was shipped and documented as Windows-only (PyInstaller .exe, .ico icon, PowerShell docs). The Python is already cross-platform, so this adds Linux packaging, a few path/icon fixes, Linux docs, and CI.

- paths.py: portable_base_dir() resolves portable state next to the .AppImage file via $APPIMAGE (AppImages mount read-only), falling back to the frozen executable dir then cwd; bundled_resource_dir() is _MEIPASS aware
- run_gui.py / gui/app.py: use the shared helpers; icon loading prefers the cross-platform PNG over the Windows .ico and is bundle aware
- packaging/dwarf_alpaca_gui.spec: one cross-platform PyInstaller spec
- scripts/build_appimage.sh + packaging/dwarf-alpaca-gui.desktop: AppImage build
- .github/workflows/build.yml: test + build-linux (AppImage) + build-windows
- setup_linux.md and README updates; pyproject classifiers; .gitignore
